### PR TITLE
Add Empty volume

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,8 +84,8 @@ inputs:
         required: false
         default: ''
     empty-volume:
-        description: 'Set to `true` if Empty volume should be added',
-        required: false,
+        description: 'Set to `true` if Empty volume should be added'
+        required: false
         default: 'false'
     containers:
         description: 'YAML object representing containers in this group'

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,10 @@ inputs:
         description: 'List of entries in the secrets volume. Space seperated values in "key=value" format. Space characters in the key are replaced with periods.'
         required: false
         default: ''
+    empty-volume:
+        description: 'Set to `true` if Empty volume should be added',
+        required: false,
+        default: 'false'
     containers:
         description: 'YAML object representing containers in this group'
         required: true

--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -89,7 +89,7 @@ class TaskParameters {
         this._getAzureFileShareVolume();
         this._volumes.push({
             name: "empty-vol",
-            emptyDir: null
+            emptyDir: {}
         });
         this._containers = this._getContainers(core.getInput('containers'));
     }

--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -87,6 +87,10 @@ class TaskParameters {
         this._getSecretVolume();
         this._getGitVolume();
         this._getAzureFileShareVolume();
+        this._volumes.push({
+            name: "empty-vol",
+            emptyDir: null
+        });
         this._containers = this._getContainers(core.getInput('containers'));
     }
     _getContainers(containersStr) {
@@ -136,20 +140,26 @@ class TaskParameters {
             const mounts = [];
             if (!!item['azureFileVolumeMountPath'] && typeof item['azureFileVolumeMountPath'] === 'string') {
                 mounts.push({
-                    "name": "azure-file-share-vol",
-                    "mountPath": item['azureFileVolumeMountPath']
+                    name: "azure-file-share-vol",
+                    mountPath: item['azureFileVolumeMountPath']
                 });
             }
             if (!!item['gitrepoMountPath'] && typeof item['gitrepoMountPath'] === 'string') {
                 mounts.push({
-                    "name": "git-repo-vol",
-                    "mountPath": item['gitrepoMountPath']
+                    name: "git-repo-vol",
+                    mountPath: item['gitrepoMountPath']
                 });
             }
             if (!!item['secretsMountPath'] && typeof item['secretsMountPath'] === 'string') {
                 mounts.push({
-                    "name": "secrets-vol",
-                    "mountPath": item['secretsMountPath']
+                    name: "secrets-vol",
+                    mountPath: item['secretsMountPath']
+                });
+            }
+            if (!!item['emptyMountPath'] && typeof item['emptyMountPath'] === 'string') {
+                mounts.push({
+                    name: 'empty-vol',
+                    mountPath: item['emptyMountPath']
                 });
             }
             container.volumeMounts = mounts;
@@ -183,8 +193,8 @@ class TaskParameters {
                 // value is either wrapped in quotes or not
                 let pairList = pair.split(/=(?:"(.+)"|(.+))/);
                 let obj = {
-                    "name": pairList[0],
-                    "value": pairList[1] || pairList[2]
+                    name: pairList[0],
+                    value: pairList[1] || pairList[2]
                 };
                 variables.push(obj);
             });
@@ -196,8 +206,8 @@ class TaskParameters {
                 // value is either wrapped in quotes or not
                 let pairList = pair.split(/=(?:"(.+)"|(.+))/);
                 let obj = {
-                    "name": pairList[0],
-                    "value": pairList[1] || pairList[2]
+                    name: pairList[0],
+                    secureValue: pairList[1] || pairList[2]
                 };
                 variables.push(obj);
             });
@@ -217,7 +227,7 @@ class TaskParameters {
             accumulator[keyval[0].replace('_', '.')] = keyval[1] || '';
             return accumulator;
         }, {});
-        this._volumes.push({ "name": "secrets-vol", secret: secretsMap });
+        this._volumes.push({ name: "secrets-vol", secret: secretsMap });
     }
     _getGitVolume() {
         const gitRepoVolumeUrl = core.getInput('gitrepo-url');
@@ -233,7 +243,7 @@ class TaskParameters {
         if (gitRepoRevision) {
             vol.revision = gitRepoRevision;
         }
-        this._volumes.push({ "name": "git-repo-vol", gitRepo: vol });
+        this._volumes.push({ name: "git-repo-vol", gitRepo: vol });
     }
     _getAzureFileShareVolume() {
         const afsAccountName = core.getInput('azure-file-volume-account-name');
@@ -259,7 +269,7 @@ class TaskParameters {
             }
             vol.readOnly = (afsReadOnly == "true");
         }
-        this._volumes.push({ "name": "azure-file-share-vol", azureFile: vol });
+        this._volumes.push({ name: "azure-file-share-vol", azureFile: vol });
     }
     static parsePort(portStr) {
         if (portStr.indexOf(':') > 0) {

--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -269,11 +269,13 @@ class TaskParameters {
         this._volumes.push({ name: "azure-file-share-vol", azureFile: vol });
     }
     _getEmptyFileVolue() {
-        const hasEmptyVolume = core.getInput('empty-volume');
-        if (!hasEmptyVolume) {
-            return;
+        const emptyVolume = core.getInput('empty-volume') || "false";
+        if (["true", "false"].indexOf(emptyVolume) < 0) {
+            throw Error("The Empty-Volume Flag can only be `true` or `false`");
         }
-        this._volumes.push({ name: "empty-vol", emptyDir: {} });
+        if (emptyVolume === "true") {
+            this._volumes.push({ name: "empty-vol", emptyDir: {} });
+        }
     }
     static parsePort(portStr) {
         if (portStr.indexOf(':') > 0) {

--- a/lib/taskparameters.js
+++ b/lib/taskparameters.js
@@ -87,10 +87,7 @@ class TaskParameters {
         this._getSecretVolume();
         this._getGitVolume();
         this._getAzureFileShareVolume();
-        this._volumes.push({
-            name: "empty-vol",
-            emptyDir: {}
-        });
+        this._getEmptyFileVolue();
         this._containers = this._getContainers(core.getInput('containers'));
     }
     _getContainers(containersStr) {
@@ -270,6 +267,13 @@ class TaskParameters {
             vol.readOnly = (afsReadOnly == "true");
         }
         this._volumes.push({ name: "azure-file-share-vol", azureFile: vol });
+    }
+    _getEmptyFileVolue() {
+        const hasEmptyVolume = core.getInput('empty-volume');
+        if (!hasEmptyVolume) {
+            return;
+        }
+        this._volumes.push({ name: "empty-vol", emptyDir: {} });
     }
     static parsePort(portStr) {
         if (portStr.indexOf(':') > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aci-deploy",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "GitHub Action to Deploy to Azure Container Groups with multiple containers",
   "main": "lib/main.js",
   "scripts": {

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -84,10 +84,7 @@ export class TaskParameters {
         this._getSecretVolume();
         this._getGitVolume();
         this._getAzureFileShareVolume();
-        this._volumes.push({
-            name: "empty-vol",
-            emptyDir: {}
-        });
+        this._getEmptyFileVolue();
 
         this._containers = this._getContainers(core.getInput('containers'));
     }
@@ -284,6 +281,14 @@ export class TaskParameters {
             vol.readOnly = (afsReadOnly == "true");
         }
         this._volumes.push({ name: "azure-file-share-vol", azureFile: vol });
+    }
+
+    private _getEmptyFileVolue() {
+        const hasEmptyVolume = core.getInput('empty-volume');
+        if (!hasEmptyVolume) {
+            return;
+        }
+        this._volumes.push({ name: "empty-vol", emptyDir: {} });
     }
 
     private static parsePort(portStr: string): ContainerInstanceManagementModels.Port {

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -284,11 +284,13 @@ export class TaskParameters {
     }
 
     private _getEmptyFileVolue() {
-        const hasEmptyVolume = core.getInput('empty-volume');
-        if (!hasEmptyVolume) {
-            return;
+        const emptyVolume = core.getInput('empty-volume') || "false";
+        if (["true", "false"].indexOf(emptyVolume) < 0) {
+            throw Error("The Empty-Volume Flag can only be `true` or `false`");
         }
-        this._volumes.push({ name: "empty-vol", emptyDir: {} });
+        if (emptyVolume === "true") {
+            this._volumes.push({ name: "empty-vol", emptyDir: {} });
+        }
     }
 
     private static parsePort(portStr: string): ContainerInstanceManagementModels.Port {

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -84,6 +84,10 @@ export class TaskParameters {
         this._getSecretVolume();
         this._getGitVolume();
         this._getAzureFileShareVolume();
+        this._volumes.push({
+            name: "empty-vol",
+            emptyDir: null
+        });
 
         this._containers = this._getContainers(core.getInput('containers'));
     }
@@ -154,6 +158,12 @@ export class TaskParameters {
                 mounts.push({ 
                     name: "secrets-vol",
                     mountPath: item['secretsMountPath']
+                });
+            }
+            if (!!item['emptyMountPath'] && typeof item['emptyMountPath'] === 'string') {
+                mounts.push({
+                    name: 'empty-vol',
+                    mountPath: item['emptyMountPath']
                 });
             }
             container.volumeMounts = mounts;

--- a/src/taskparameters.ts
+++ b/src/taskparameters.ts
@@ -86,7 +86,7 @@ export class TaskParameters {
         this._getAzureFileShareVolume();
         this._volumes.push({
             name: "empty-vol",
-            emptyDir: null
+            emptyDir: {}
         });
 
         this._containers = this._getContainers(core.getInput('containers'));


### PR DESCRIPTION
Add support for EmptyDir volumes on Azure container groups - see https://docs.microsoft.com/en-us/azure/container-instances/container-instances-volume-emptydir - "Use emptyDir volumes as ephemeral caches for your containerized workloads."